### PR TITLE
With unittest, skipping a test should actually skip instead of asserting False

### DIFF
--- a/pythoscope/generator/builder.py
+++ b/pythoscope/generator/builder.py
@@ -30,7 +30,7 @@ class UnittestTemplate(Template):
     def raises_assertion(self, exception, call):
         return combine(exception, call, "self.assertRaises(%s, %s)")
     def skip_test(self):
-        return CodeString("assert False # TODO: implement your test here")
+        return CodeString("self.skipTest('# TODO: implement your test here.')")
 
 class NoseTemplate(Template):
     def equal_assertion(self, expected, actual):


### PR DESCRIPTION
I found that skipping a test with the explicit unittest.skipTest makes more sense than "assert False", since a test that isn't implemented doesn't necessarily meant that the code is broken.
