### PR TITLE
Pep8 compatability for generated templates

### DIFF
--- a/pythoscope/generator/adder.py
+++ b/pythoscope/generator/adder.py
@@ -102,7 +102,8 @@ def insert_after_other_imports(module, code):
     if last_import:
         insert_after(last_import, code)
     else:
-        # Add an extra newline separating imports from the code.
+        # Add 2 extra newlines separating imports from the code.
+        code_of(module).insert_child(0, Newline())
         code_of(module).insert_child(0, Newline())
         code_of(module).insert_child(0, code)
     # Just inserted import becomes the last one.

--- a/pythoscope/generator/builder.py
+++ b/pythoscope/generator/builder.py
@@ -30,7 +30,7 @@ class UnittestTemplate(Template):
     def raises_assertion(self, exception, call):
         return combine(exception, call, "self.assertRaises(%s, %s)")
     def skip_test(self):
-        return CodeString("assert False # TODO: implement your test here")
+        return CodeString("assert False  # TODO: implement your test here")
 
 class NoseTemplate(Template):
     def equal_assertion(self, expected, actual):


### PR DESCRIPTION
Added:
- 2 lines after last import and before start of code
- 2 spaces between end of code and start of inline comment
